### PR TITLE
Add authentication guards to mobile and admin apps

### DIFF
--- a/admin/app/layout.tsx
+++ b/admin/app/layout.tsx
@@ -8,7 +8,8 @@ import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
 import { QueryProvider } from '@/lib/query-client';
-import { Navigation } from '@/modules/admin/components/shared/Navigation';
+import { AdminAuthProvider } from '@/modules/admin/components/auth/AdminAuthProvider';
+import { AdminShell } from '@/modules/admin/components/shared/AdminShell';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -26,12 +27,9 @@ export default function RootLayout({
     <html lang="en">
       <body className={inter.className}>
         <QueryProvider>
-          <div className="min-h-screen bg-gray-50">
-            <Navigation />
-            <main className="container mx-auto px-4 py-8">
-              {children}
-            </main>
-          </div>
+          <AdminAuthProvider>
+            <AdminShell>{children}</AdminShell>
+          </AdminAuthProvider>
         </QueryProvider>
       </body>
     </html>

--- a/admin/modules/admin/components/auth/AdminAuthProvider.tsx
+++ b/admin/modules/admin/components/auth/AdminAuthProvider.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+type AdminUser = {
+  id: number;
+  email: string;
+  name: string;
+  role: string;
+};
+
+interface AdminAuthContextValue {
+  user: AdminUser | null;
+  signIn(user: AdminUser): void;
+  signOut(): void;
+  isHydrated: boolean;
+}
+
+const STORAGE_KEY = 'deeplearn/admin/current-user';
+
+const AdminAuthContext = createContext<AdminAuthContextValue | undefined>(
+  undefined
+);
+
+function readStoredUser(): AdminUser | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return null;
+    }
+    const parsed = JSON.parse(stored) as AdminUser;
+    if (!parsed || typeof parsed !== 'object' || parsed.id === undefined) {
+      return null;
+    }
+    return parsed;
+  } catch (error) {
+    console.warn('[AdminAuth] Failed to parse stored user', error);
+    return null;
+  }
+}
+
+export function AdminAuthProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement {
+  const [user, setUser] = useState<AdminUser | null>(null);
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  useEffect(() => {
+    const storedUser = readStoredUser();
+    if (storedUser) {
+      setUser(storedUser);
+    }
+    setIsHydrated(true);
+  }, []);
+
+  const signIn = useCallback((nextUser: AdminUser) => {
+    setUser(nextUser);
+    if (typeof window !== 'undefined') {
+      try {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(nextUser));
+      } catch (error) {
+        console.warn('[AdminAuth] Failed to persist user', error);
+      }
+    }
+  }, []);
+
+  const signOut = useCallback(() => {
+    setUser(null);
+    if (typeof window !== 'undefined') {
+      window.localStorage.removeItem(STORAGE_KEY);
+    }
+  }, []);
+
+  const value = useMemo<AdminAuthContextValue>(
+    () => ({ user, signIn, signOut, isHydrated }),
+    [user, signIn, signOut, isHydrated]
+  );
+
+  return (
+    <AdminAuthContext.Provider value={value}>
+      {children}
+    </AdminAuthContext.Provider>
+  );
+}
+
+export function useAdminAuth(): AdminAuthContextValue {
+  const context = useContext(AdminAuthContext);
+  if (!context) {
+    throw new Error('useAdminAuth must be used within an AdminAuthProvider');
+  }
+  return context;
+}

--- a/admin/modules/admin/components/auth/LoginPanel.tsx
+++ b/admin/modules/admin/components/auth/LoginPanel.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import React, { FormEvent, useMemo, useState } from 'react';
+import { useAdminAuth } from './AdminAuthProvider';
+
+const API_BASE = (process.env.NEXT_PUBLIC_API_BASE_URL ?? '').replace(/\/$/, '');
+
+interface LoginResponse {
+  user: {
+    id: number;
+    email: string;
+    name: string;
+    role: string;
+  };
+}
+
+export function LoginPanel(): React.ReactElement {
+  const { signIn } = useAdminAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const loginEndpoint = useMemo(() => {
+    const base = API_BASE;
+    if (!base) {
+      return '/api/v1/users/login';
+    }
+    return `${base}/api/v1/users/login`;
+  }, []);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      const response = await fetch(loginEndpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ email, password }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        const message = data?.detail ?? 'Invalid email or password.';
+        throw new Error(message);
+      }
+
+      const payload = (await response.json()) as LoginResponse;
+      if (!payload?.user) {
+        throw new Error('Unexpected response from server.');
+      }
+
+      if (payload.user.role?.toLowerCase() !== 'admin') {
+        throw new Error('This account does not have admin access.');
+      }
+
+      signIn({
+        id: payload.user.id,
+        email: payload.user.email,
+        name: payload.user.name || payload.user.email,
+        role: payload.user.role,
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to login.';
+      setError(message);
+    } finally {
+      setIsSubmitting(false);
+      setPassword('');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-indigo-100 flex items-center justify-center px-4 py-12">
+      <div className="w-full max-w-md rounded-2xl bg-white shadow-xl border border-blue-100 p-8 space-y-8">
+        <div className="text-center space-y-2">
+          <h1 className="text-3xl font-semibold text-gray-900">Admin Access</h1>
+          <p className="text-gray-600">
+            Sign in with your administrator credentials to manage DeepLearn.
+          </p>
+        </div>
+
+        <form className="space-y-6" onSubmit={handleSubmit}>
+          <div className="space-y-2">
+            <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              autoComplete="email"
+              required
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              disabled={isSubmitting}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              autoComplete="current-password"
+              required
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              disabled={isSubmitting}
+              className="w-full rounded-lg border border-gray-300 px-3 py-2 text-gray-900 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200"
+            />
+          </div>
+
+          {error && (
+            <p className="text-sm text-red-600 bg-red-50 border border-red-100 rounded-lg px-3 py-2">
+              {error}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2.5 text-white font-medium shadow hover:bg-blue-700 transition-colors disabled:opacity-60"
+          >
+            {isSubmitting ? 'Signing in…' : 'Sign in'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/admin/modules/admin/components/shared/AdminShell.tsx
+++ b/admin/modules/admin/components/shared/AdminShell.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import React from 'react';
+import { Navigation } from './Navigation';
+import { LoginPanel } from '../auth/LoginPanel';
+import { useAdminAuth } from '../auth/AdminAuthProvider';
+
+export function AdminShell({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement {
+  const { user, isHydrated } = useAdminAuth();
+
+  if (!isHydrated) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <span className="text-gray-500 text-sm">Loading dashboard…</span>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <LoginPanel />;
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navigation />
+      <main className="container mx-auto px-4 py-8">{children}</main>
+    </div>
+  );
+}

--- a/admin/modules/admin/components/shared/Navigation.tsx
+++ b/admin/modules/admin/components/shared/Navigation.tsx
@@ -9,6 +9,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
+import { useAdminAuth } from '../auth/AdminAuthProvider';
 
 const navigationItems = [
   {
@@ -50,6 +51,7 @@ const navigationItems = [
 
 export function Navigation() {
   const pathname = usePathname();
+  const { user, signOut } = useAdminAuth();
 
   return (
     <nav className="bg-white shadow-sm border-b">
@@ -87,9 +89,28 @@ export function Navigation() {
           </div>
 
           {/* Status Indicator */}
-          <div className="flex items-center space-x-2">
-            <div className="w-2 h-2 bg-green-500 rounded-full"></div>
-            <span className="text-sm text-gray-600">Online</span>
+          <div className="flex items-center space-x-4">
+            {user && (
+              <div className="hidden sm:flex flex-col items-end">
+                <span className="text-sm font-medium text-gray-900">
+                  {user.name || user.email}
+                </span>
+                <span className="text-xs text-gray-500 capitalize">
+                  {user.role}
+                </span>
+              </div>
+            )}
+            <button
+              type="button"
+              onClick={signOut}
+              className="inline-flex items-center rounded-md border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900"
+            >
+              Sign out
+            </button>
+            <div className="flex items-center space-x-2">
+              <div className="w-2 h-2 bg-green-500 rounded-full"></div>
+              <span className="text-sm text-gray-600">Online</span>
+            </div>
           </div>
         </div>
       </div>

--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -11,6 +11,7 @@ import type { Theme as NavigationTheme } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ActivityIndicator, StyleSheet, View } from 'react-native';
 
 // Screens (using new modular structure)
 import { LessonListScreen } from './modules/catalog/screens/UnitListScreen';
@@ -18,6 +19,9 @@ import { CreateUnitScreen } from './modules/catalog/screens/CreateUnitScreen';
 import LearningFlowScreen from './modules/learning_session/screens/LearningFlowScreen';
 import ResultsScreen from './modules/learning_session/screens/ResultsScreen';
 import { UnitDetailScreen } from './modules/catalog/screens/UnitDetailScreen';
+import AuthLandingScreen from './modules/user/screens/AuthLandingScreen';
+import LoginScreen from './modules/user/screens/LoginScreen';
+import RegisterScreen from './modules/user/screens/RegisterScreen';
 
 // Types
 import type { RootStackParamList, LearningStackParamList } from './types';
@@ -25,6 +29,7 @@ import type { RootStackParamList, LearningStackParamList } from './types';
 // Theme (using new modular structure)
 import { uiSystemProvider } from './modules/ui_system/public';
 import { reducedMotion } from './modules/ui_system/utils/motion';
+import { AuthProvider, useAuth } from './modules/user/public';
 
 // Create navigators
 const RootStack = createNativeStackNavigator<RootStackParamList>();
@@ -100,6 +105,21 @@ function LearningStackNavigator(): React.ReactElement {
 function RootNavigator(): React.ReactElement {
   const uiSystem = uiSystemProvider();
   const theme = uiSystem.getCurrentTheme();
+  const { user, isHydrated } = useAuth();
+
+  if (!isHydrated) {
+    return (
+      <View
+        style={[
+          styles.loadingContainer,
+          { backgroundColor: theme.colors.background },
+        ]}
+      >
+        <ActivityIndicator color={theme.colors.primary} size="large" />
+      </View>
+    );
+  }
+
   return (
     <RootStack.Navigator
       id={undefined}
@@ -109,15 +129,26 @@ function RootNavigator(): React.ReactElement {
         animationDuration: 220,
         contentStyle: { backgroundColor: theme.colors.background },
       }}
+      initialRouteName={user ? 'Dashboard' : 'AuthLanding'}
     >
-      <RootStack.Screen name="Dashboard" component={LearningStackNavigator} />
-      <RootStack.Screen
-        name="LessonDetail"
-        component={LearningFlowScreen as any}
-        options={{
-          gestureEnabled: false, // Prevent swipe back during learning
-        }}
-      />
+      {user ? (
+        <>
+          <RootStack.Screen name="Dashboard" component={LearningStackNavigator} />
+          <RootStack.Screen
+            name="LessonDetail"
+            component={LearningFlowScreen as any}
+            options={{
+              gestureEnabled: false, // Prevent swipe back during learning
+            }}
+          />
+        </>
+      ) : (
+        <>
+          <RootStack.Screen name="AuthLanding" component={AuthLandingScreen} />
+          <RootStack.Screen name="Login" component={LoginScreen} />
+          <RootStack.Screen name="Register" component={RegisterScreen} />
+        </>
+      )}
     </RootStack.Navigator>
   );
 }
@@ -149,17 +180,27 @@ export default function App(): React.ReactElement {
     // eslint-disable-next-line react-native/no-inline-styles
     <GestureHandlerRootView style={{ flex: 1 }}>
       <QueryClientProvider client={queryClient}>
-        <NavigationContainer theme={navigationTheme}>
-          <StatusBar
-            style={
-              uiSystem.isLightColor(theme.colors.surface) ? 'dark' : 'light'
-            }
-            backgroundColor={theme.colors.surface}
-            translucent={false}
-          />
-          <RootNavigator />
-        </NavigationContainer>
+        <AuthProvider>
+          <NavigationContainer theme={navigationTheme}>
+            <StatusBar
+              style={
+                uiSystem.isLightColor(theme.colors.surface) ? 'dark' : 'light'
+              }
+              backgroundColor={theme.colors.surface}
+              translucent={false}
+            />
+            <RootNavigator />
+          </NavigationContainer>
+        </AuthProvider>
       </QueryClientProvider>
     </GestureHandlerRootView>
   );
 }
+
+const styles = StyleSheet.create({
+  loadingContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/mobile/modules/catalog/screens/CreateUnitScreen.tsx
+++ b/mobile/modules/catalog/screens/CreateUnitScreen.tsx
@@ -22,6 +22,7 @@ import { uiSystemProvider, useHaptics } from '../../ui_system/public';
 import { useNavigation } from '@react-navigation/native';
 import type { Difficulty } from '../models';
 import { useCreateUnit } from '../queries';
+import { useAuth } from '../../user/public';
 
 interface CreateUnitFormData {
   topic: string;
@@ -42,7 +43,8 @@ export function CreateUnitScreen() {
   const ui = uiSystemProvider();
   const theme = ui.getCurrentTheme();
   const haptics = useHaptics();
-  const currentUserId = 1; // TODO: replace with authenticated user context
+  const { user } = useAuth();
+  const currentUserId = user?.id;
 
   const [formData, setFormData] = useState<CreateUnitFormData>({
     topic: '',
@@ -82,6 +84,11 @@ export function CreateUnitScreen() {
 
   const handleSubmit = async () => {
     if (!validateForm()) {
+      return;
+    }
+
+    if (!currentUserId) {
+      Alert.alert('Sign in required', 'Please log in to create a unit.');
       return;
     }
 

--- a/mobile/modules/catalog/screens/UnitDetailScreen.tsx
+++ b/mobile/modules/catalog/screens/UnitDetailScreen.tsx
@@ -28,6 +28,7 @@ import {
   uiSystemProvider,
   useHaptics,
 } from '../../ui_system/public';
+import { useAuth } from '../../user/public';
 
 type UnitDetailScreenNavigationProp = NativeStackNavigationProp<
   LearningStackParamList,
@@ -38,16 +39,16 @@ export function UnitDetailScreen() {
   const route = useRoute<RouteProp<LearningStackParamList, 'UnitDetail'>>();
   const unitId = route.params?.unitId as string | undefined;
   const navigation = useNavigation<UnitDetailScreenNavigationProp>();
-  const currentUserId = 1; // TODO: replace with authenticated user context
+  const { user } = useAuth();
+  const currentUserId = user?.id ?? null;
   const { data: unit } = useCatalogUnitDetail(unitId || '', {
-    currentUserId,
+    currentUserId: currentUserId ?? undefined,
   });
   const toggleSharing = useToggleUnitSharing();
   const ui = uiSystemProvider();
   const theme = ui.getCurrentTheme();
   const haptics = useHaptics();
-  // For now, use placeholder user until auth is wired up
-  const userKey = String(currentUserId || 'anonymous');
+  const userKey = currentUserId ? String(currentUserId) : 'anonymous';
   const { data: progressLS } = useUnitProgressLS(userKey, unit?.id || '', {
     enabled: !!unit?.id,
     staleTime: 60 * 1000,
@@ -75,7 +76,7 @@ export function UnitDetailScreen() {
     toggleSharing.mutate({
       unitId: unit.id,
       makeGlobal: nextValue,
-      actingUserId: currentUserId,
+      actingUserId: currentUserId ?? undefined,
     });
   };
 

--- a/mobile/modules/catalog/screens/UnitListScreen.tsx
+++ b/mobile/modules/catalog/screens/UnitListScreen.tsx
@@ -29,6 +29,7 @@ import {
 import type { Unit } from '../public';
 import type { LearningStackParamList } from '../../../types';
 import { uiSystemProvider, Text, useHaptics } from '../../ui_system/public';
+import { useAuth } from '../../user/public';
 
 type LessonListScreenNavigationProp = NativeStackNavigationProp<
   LearningStackParamList,
@@ -44,7 +45,8 @@ type UnitSection = {
 export function LessonListScreen() {
   const navigation = useNavigation<LessonListScreenNavigationProp>();
   const [searchQuery, setSearchQuery] = useState('');
-  const currentUserId = 1; // TODO: replace with authenticated user context
+  const { user } = useAuth();
+  const currentUserId = user?.id ?? 0;
   const {
     data: collections,
     isLoading,
@@ -102,6 +104,9 @@ export function LessonListScreen() {
 
   const handleRetryUnit = useCallback(
     (unitId: string) => {
+      if (!currentUserId) {
+        return;
+      }
       retryUnitMutation.mutate(
         { unitId, ownerUserId: currentUserId },
         { onSuccess: () => refetch() }
@@ -112,6 +117,9 @@ export function LessonListScreen() {
 
   const handleDismissUnit = useCallback(
     (unitId: string) => {
+      if (!currentUserId) {
+        return;
+      }
       dismissUnitMutation.mutate(
         { unitId, ownerUserId: currentUserId },
         { onSuccess: () => refetch() }

--- a/mobile/modules/user/context.tsx
+++ b/mobile/modules/user/context.tsx
@@ -1,0 +1,105 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useQueryClient } from '@tanstack/react-query';
+import type { User } from './models';
+import { userQueryKeys } from './queries';
+
+interface AuthContextValue {
+  user: User | null;
+  signIn(user: User): Promise<void>;
+  signOut(): Promise<void>;
+  isHydrated: boolean;
+}
+
+const STORAGE_KEY = 'deeplearn/mobile/current-user';
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+async function loadStoredUser(): Promise<User | null> {
+  try {
+    const value = await AsyncStorage.getItem(STORAGE_KEY);
+    if (!value) {
+      return null;
+    }
+
+    const parsed = JSON.parse(value) as User;
+    if (!parsed || typeof parsed !== 'object' || parsed.id === undefined) {
+      return null;
+    }
+
+    return parsed;
+  } catch (error) {
+    console.warn('[Auth] Failed to load stored user', error);
+    return null;
+  }
+}
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const queryClient = useQueryClient();
+  const [user, setUser] = useState<User | null>(null);
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    loadStoredUser().then(storedUser => {
+      if (isMounted && storedUser) {
+        setUser(storedUser);
+        queryClient.setQueryData(userQueryKeys.profile(storedUser.id), storedUser);
+      }
+      if (isMounted) {
+        setIsHydrated(true);
+      }
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [queryClient]);
+
+  const signIn = useCallback(
+    async (nextUser: User) => {
+      setUser(nextUser);
+      queryClient.setQueryData(userQueryKeys.profile(nextUser.id), nextUser);
+
+      try {
+        await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(nextUser));
+      } catch (error) {
+        console.warn('[Auth] Failed to persist user', error);
+      }
+    },
+    [queryClient]
+  );
+
+  const signOut = useCallback(async () => {
+    setUser(null);
+    try {
+      await AsyncStorage.removeItem(STORAGE_KEY);
+    } catch (error) {
+      console.warn('[Auth] Failed to clear stored user', error);
+    }
+    queryClient.removeQueries({ queryKey: ['user'] });
+  }, [queryClient]);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({ user, signIn, signOut, isHydrated }),
+    [user, signIn, signOut, isHydrated]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthContextValue {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/mobile/modules/user/public.ts
+++ b/mobile/modules/user/public.ts
@@ -33,3 +33,4 @@ export function userProvider(): UserProvider {
 }
 
 export type { User, LoginRequest, RegisterRequest, UpdateProfileRequest } from './models';
+export { AuthProvider, useAuth } from './context';

--- a/mobile/modules/user/screens/AuthLandingScreen.tsx
+++ b/mobile/modules/user/screens/AuthLandingScreen.tsx
@@ -1,0 +1,91 @@
+import React, { useMemo } from 'react';
+import { SafeAreaView, StyleSheet, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { Button, Text, uiSystemProvider } from '../../ui_system/public';
+import type { Theme } from '../../ui_system/models';
+import type { RootStackParamList } from '../../../types';
+
+type AuthLandingNavigationProp = NativeStackNavigationProp<
+  RootStackParamList,
+  'AuthLanding'
+>;
+
+export default function AuthLandingScreen(): React.ReactElement {
+  const uiSystem = uiSystemProvider();
+  const theme = uiSystem.getCurrentTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
+  const navigation = useNavigation<AuthLandingNavigationProp>();
+
+  return (
+    <SafeAreaView style={[styles.safeArea, { backgroundColor: theme.colors.background }]}> 
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <Text style={styles.title}>DeepLearn</Text>
+          <Text style={styles.subtitle}>
+            Personalized learning journeys powered by AI. Sign in or create an
+            account to get started.
+          </Text>
+        </View>
+
+        <View style={styles.actions}>
+          <Button
+            title="Log in"
+            size="large"
+            fullWidth
+            onPress={() => navigation.navigate('Login')}
+          />
+          <Button
+            title="Create an account"
+            variant="secondary"
+            size="large"
+            fullWidth
+            onPress={() => navigation.navigate('Register')}
+          />
+        </View>
+
+        <View style={styles.footer}>
+          <Text style={styles.footerText}>
+            Need help? Contact support@deeplearn.app
+          </Text>
+        </View>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const createStyles = (theme: Theme) =>
+  StyleSheet.create({
+    safeArea: {
+      flex: 1,
+    },
+    container: {
+      flex: 1,
+      padding: 24,
+      justifyContent: 'space-between',
+    },
+    header: {
+      marginTop: 32,
+      gap: 16,
+    },
+    title: {
+      fontSize: 32,
+      fontWeight: '700',
+      color: theme.colors.text,
+    },
+    subtitle: {
+      fontSize: 16,
+      color: theme.colors.textSecondary,
+      lineHeight: 24,
+    },
+    actions: {
+      gap: 16,
+    },
+    footer: {
+      alignItems: 'center',
+    },
+    footerText: {
+      fontSize: 13,
+      color: theme.colors.textSecondary,
+    },
+  });

--- a/mobile/modules/user/screens/LoginScreen.tsx
+++ b/mobile/modules/user/screens/LoginScreen.tsx
@@ -9,18 +9,25 @@ import {
   TextInput,
   View,
 } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Button, Text, uiSystemProvider } from '../../ui_system/public';
 import { useLogin } from '../queries';
 import type { Theme } from '../../ui_system/models';
+import { useAuth } from '../context';
+import type { RootStackParamList } from '../../../types';
 
-interface Props {
-  onLoginSuccess?: (userId: number) => void;
-}
+type LoginScreenNavigationProp = NativeStackNavigationProp<
+  RootStackParamList,
+  'Login'
+>;
 
-export default function LoginScreen({ onLoginSuccess }: Props) {
+export default function LoginScreen() {
   const uiSystem = uiSystemProvider();
   const theme = uiSystem.getCurrentTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
+  const navigation = useNavigation<LoginScreenNavigationProp>();
+  const auth = useAuth();
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -30,9 +37,7 @@ export default function LoginScreen({ onLoginSuccess }: Props) {
   const handleSubmit = async () => {
     try {
       const user = await loginMutation.mutateAsync({ email, password });
-      if (onLoginSuccess) {
-        onLoginSuccess(user.id);
-      }
+      await auth.signIn(user);
     } catch (error: any) {
       const message = error?.message ?? 'Unable to login. Please try again.';
       Alert.alert('Login failed', message);
@@ -91,6 +96,18 @@ export default function LoginScreen({ onLoginSuccess }: Props) {
             <Text style={styles.loadingText}>Authenticating…</Text>
           </View>
         )}
+
+        <View style={styles.footer}>
+          <Text style={styles.footerText}>
+            Don&apos;t have an account?{' '}
+            <Text
+              style={[styles.footerText, styles.link]}
+              onPress={() => navigation.navigate('Register')}
+            >
+              Create one
+            </Text>
+          </Text>
+        </View>
       </KeyboardAvoidingView>
     </SafeAreaView>
   );
@@ -149,5 +166,17 @@ const createStyles = (theme: Theme) =>
     loadingText: {
       fontSize: 14,
       color: theme.colors.textSecondary,
+    },
+    footer: {
+      marginTop: 32,
+      alignItems: 'center',
+    },
+    footerText: {
+      fontSize: 14,
+      color: theme.colors.textSecondary,
+    },
+    link: {
+      color: theme.colors.primary,
+      fontWeight: '600',
     },
   });

--- a/mobile/modules/user/screens/RegisterScreen.tsx
+++ b/mobile/modules/user/screens/RegisterScreen.tsx
@@ -9,18 +9,23 @@ import {
   TextInput,
   View,
 } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Button, Text, uiSystemProvider } from '../../ui_system/public';
 import type { Theme } from '../../ui_system/models';
 import { useRegister } from '../queries';
+import type { RootStackParamList } from '../../../types';
 
-interface Props {
-  onRegistered?: (userId: number) => void;
-}
+type RegisterScreenNavigationProp = NativeStackNavigationProp<
+  RootStackParamList,
+  'Register'
+>;
 
-export default function RegisterScreen({ onRegistered }: Props) {
+export default function RegisterScreen() {
   const uiSystem = uiSystemProvider();
   const theme = uiSystem.getCurrentTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
+  const navigation = useNavigation<RegisterScreenNavigationProp>();
 
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
@@ -36,15 +41,21 @@ export default function RegisterScreen({ onRegistered }: Props) {
     }
 
     try {
-      const user = await registerMutation.mutateAsync({
+      await registerMutation.mutateAsync({
         email,
         password,
         name,
       });
-      if (onRegistered) {
-        onRegistered(user.id);
-      }
-      Alert.alert('Registration complete', 'You can now sign in.');
+      Alert.alert('Registration complete', 'You can now sign in.', [
+        {
+          text: 'Go to login',
+          onPress: () => navigation.navigate('Login'),
+        },
+      ]);
+      setName('');
+      setEmail('');
+      setPassword('');
+      setConfirmPassword('');
     } catch (error: any) {
       const message = error?.message ?? 'Unable to complete registration.';
       Alert.alert('Registration failed', message);
@@ -127,6 +138,18 @@ export default function RegisterScreen({ onRegistered }: Props) {
             disabled={registerMutation.isPending}
             loading={registerMutation.isPending}
           />
+
+          <View style={styles.footer}>
+            <Text style={styles.footerText}>
+              Already have an account?{' '}
+              <Text
+                style={[styles.footerText, styles.link]}
+                onPress={() => navigation.navigate('Login')}
+              >
+                Sign in
+              </Text>
+            </Text>
+          </View>
         </ScrollView>
       </KeyboardAvoidingView>
     </SafeAreaView>
@@ -176,5 +199,17 @@ const createStyles = (theme: Theme) =>
       fontSize: 16,
       backgroundColor: theme.colors.surface,
       color: theme.colors.text,
+    },
+    footer: {
+      marginTop: 24,
+      alignItems: 'center',
+    },
+    footerText: {
+      fontSize: 14,
+      color: theme.colors.textSecondary,
+    },
+    link: {
+      color: theme.colors.primary,
+      fontWeight: '600',
     },
   });

--- a/mobile/types.ts
+++ b/mobile/types.ts
@@ -12,6 +12,9 @@ import type { SessionResults } from './modules/learning_session/models';
 // ================================
 
 export type RootStackParamList = {
+  AuthLanding: undefined;
+  Login: undefined;
+  Register: undefined;
   Dashboard: undefined;
   Learning: { lessonId: string };
   LessonDetail: { lessonId: string; lesson: LessonDetail };


### PR DESCRIPTION
## Summary
- introduce an auth context and login/register entry flow for the React Native app so learners land on an authentication screen before accessing catalog content
- wire catalog screens to the authenticated user context for ownership-aware actions
- wrap the Next.js admin dashboard in a client-side auth provider with a dedicated login panel and navigation sign-out control

## Testing
- npm run lint (admin)  
- npm run lint (mobile) *(fails: existing Prettier/ESLint violations throughout the project)*  

------
https://chatgpt.com/codex/tasks/task_e_68d87448e518832c999f16be1eaf09a3