### PR TITLE
Track exercise attempts and surface unit objective progress

### DIFF
--- a/admin/app/units/[id]/page.tsx
+++ b/admin/app/units/[id]/page.tsx
@@ -91,6 +91,40 @@ export default function UnitDetailsPage({ params }: UnitDetailsPageProps) {
         </div>
       )}
 
+      {unit.learning_objective_progress && unit.learning_objective_progress.length > 0 && (
+        <div className="bg-white rounded-lg shadow">
+          <div className="px-6 py-4 border-b border-gray-200">
+            <h2 className="text-lg font-medium text-gray-900">Learning Objective Progress</h2>
+            <p className="text-sm text-gray-600">Based on recorded exercise attempts across this unit.</p>
+          </div>
+          <div className="px-6 py-4 space-y-4">
+            {unit.learning_objective_progress.map((lo, idx) => {
+              const percent = Math.min(Math.max(lo.progress_percentage ?? 0, 0), 100);
+              return (
+                <div key={`${lo.objective}-${idx}`} className="space-y-2">
+                  <div className="flex items-center justify-between text-sm font-medium text-gray-700">
+                    <span>{lo.objective}</span>
+                    <span>
+                      {lo.exercises_correct}/{lo.exercises_total} correct
+                    </span>
+                  </div>
+                  <div className="w-full bg-gray-100 rounded-full h-2">
+                    <div
+                      className="h-2 rounded-full bg-green-500"
+                      style={{ width: `${percent}%` }}
+                      aria-hidden="true"
+                    />
+                  </div>
+                  <div className="text-xs text-gray-500">
+                    {Math.round(percent)}% complete
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
       <div className="bg-white rounded-lg shadow">
         <div className="px-6 py-4 border-b border-gray-200">
           <h2 className="text-lg font-medium text-gray-900">Lessons</h2>

--- a/admin/modules/admin/models.ts
+++ b/admin/modules/admin/models.ts
@@ -437,6 +437,7 @@ export interface ApiUnitDetail {
   source_material?: string | null;
   generated_from_topic?: boolean;
   flow_type?: 'standard' | 'fast';
+  learning_objective_progress?: LearningObjectiveProgress[] | null;
 }
 
 // Basic unit from /api/v1/units
@@ -473,6 +474,13 @@ export interface UnitLessonSummary {
   exercise_count: number;
 }
 
+export interface LearningObjectiveProgress {
+  objective: string;
+  exercises_total: number;
+  exercises_correct: number;
+  progress_percentage: number;
+}
+
 export interface UnitDetail {
   id: string;
   title: string;
@@ -486,6 +494,7 @@ export interface UnitDetail {
   source_material: string | null;
   generated_from_topic: boolean;
   flow_type: 'standard' | 'fast';
+  learning_objective_progress: LearningObjectiveProgress[] | null;
 }
 
 export type LessonToUnitMap = Record<string, { unit_id: string; unit_title: string }>;

--- a/admin/modules/admin/service.ts
+++ b/admin/modules/admin/service.ts
@@ -614,6 +614,7 @@ export class AdminService {
         source_material: d.source_material ?? null,
         generated_from_topic: Boolean(d.generated_from_topic),
         flow_type: (d.flow_type as UnitDetail['flow_type']) ?? 'standard',
+        learning_objective_progress: d.learning_objective_progress ?? null,
       };
     } catch {
       return null;

--- a/backend/modules/admin/routes.py
+++ b/backend/modules/admin/routes.py
@@ -14,7 +14,10 @@ from modules.catalog.public import catalog_provider
 from modules.content.public import content_provider
 from modules.flow_engine.public import flow_engine_admin_provider
 from modules.infrastructure.public import infrastructure_provider
-from modules.learning_session.public import learning_session_provider
+from modules.learning_session.public import (
+    learning_session_analytics_provider,
+    learning_session_provider,
+)
 from modules.llm_services.public import llm_services_admin_provider
 from modules.user.public import user_provider
 
@@ -60,7 +63,8 @@ def get_admin_service(session: Session = Depends(get_session)) -> AdminService:
     # Get other module providers (using same session for consistency)
     content = content_provider(session)
     # Units are consolidated under content provider
-    catalog = catalog_provider(content, content)
+    learning_session_analytics = learning_session_analytics_provider(session)
+    catalog = catalog_provider(content, content, learning_session_analytics)
 
     # Create placeholder providers for async services
     # In practice, these would be properly initialized with async context

--- a/backend/modules/catalog/public.py
+++ b/backend/modules/catalog/public.py
@@ -8,7 +8,7 @@ This is the only interface other modules should import from.
 from typing import Protocol
 
 from modules.content.public import ContentProvider
-from modules.learning_session.repo import LearningSessionRepo
+from modules.learning_session.public import LearningSessionAnalyticsProvider
 
 from .service import (
     BrowseLessonsResponse,
@@ -57,7 +57,7 @@ class CatalogProvider(Protocol):
 def catalog_provider(
     content: ContentProvider,
     units: ContentProvider,
-    learning_sessions: LearningSessionRepo | None = None,
+    learning_sessions: LearningSessionAnalyticsProvider | None = None,
 ) -> CatalogProvider:
     """
     Dependency injection provider for lesson catalog services.

--- a/backend/modules/catalog/public.py
+++ b/backend/modules/catalog/public.py
@@ -8,6 +8,7 @@ This is the only interface other modules should import from.
 from typing import Protocol
 
 from modules.content.public import ContentProvider
+from modules.learning_session.repo import LearningSessionRepo
 
 from .service import (
     BrowseLessonsResponse,
@@ -53,7 +54,11 @@ class CatalogProvider(Protocol):
     def refresh_catalog(self) -> RefreshCatalogResponse: ...
 
 
-def catalog_provider(content: ContentProvider, units: ContentProvider) -> CatalogProvider:
+def catalog_provider(
+    content: ContentProvider,
+    units: ContentProvider,
+    learning_sessions: LearningSessionRepo | None = None,
+) -> CatalogProvider:
     """
     Dependency injection provider for lesson catalog services.
 
@@ -64,7 +69,7 @@ def catalog_provider(content: ContentProvider, units: ContentProvider) -> Catalo
     Returns:
         CatalogService instance that implements the CatalogProvider protocol.
     """
-    return CatalogService(content, units)
+    return CatalogService(content, units, learning_sessions)
 
 
 __all__ = [

--- a/backend/modules/catalog/routes.py
+++ b/backend/modules/catalog/routes.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 
 from modules.content.public import content_provider
 from modules.infrastructure.public import infrastructure_provider
+from modules.learning_session.repo import LearningSessionRepo
 
 from .service import (
     BrowseLessonsResponse,
@@ -39,7 +40,8 @@ def get_catalog_service(s: Session = Depends(get_session)) -> CatalogService:
     """Build CatalogService for this request."""
     content_service = content_provider(s)
     units_via_content = content_service  # Units are consolidated in content provider
-    return CatalogService(content_service, units_via_content)
+    learning_sessions = LearningSessionRepo(s)
+    return CatalogService(content_service, units_via_content, learning_sessions)
 
 
 @router.get("/", response_model=BrowseLessonsResponse)

--- a/backend/modules/catalog/service.py
+++ b/backend/modules/catalog/service.py
@@ -544,11 +544,7 @@ class CatalogService:
         except Exception:
             correctness = []
 
-        correct_exercises: set[str] = {
-            record.exercise_id
-            for record in correctness
-            if record.exercise_id in exercise_to_objective and record.has_been_answered_correctly
-        }
+        correct_exercises: set[str] = {record.exercise_id for record in correctness if record.exercise_id in exercise_to_objective and record.has_been_answered_correctly}
 
         objective_texts = list(getattr(detail, "learning_objectives", []) or [])
         progress_results: list[LearningObjectiveProgress] = []
@@ -556,11 +552,7 @@ class CatalogService:
 
         def build_entry(objective_text: str) -> LearningObjectiveProgress:
             total = totals.get(objective_text, 0)
-            correct = sum(
-                1
-                for exercise_id, lo_text in exercise_to_objective.items()
-                if lo_text == objective_text and exercise_id in correct_exercises
-            )
+            correct = sum(1 for exercise_id, lo_text in exercise_to_objective.items() if lo_text == objective_text and exercise_id in correct_exercises)
             percentage = (correct / total * 100.0) if total else 0.0
             return LearningObjectiveProgress(
                 objective=objective_text,
@@ -573,7 +565,7 @@ class CatalogService:
             progress_results.append(build_entry(objective_text))
             seen.add(objective_text)
 
-        for remaining_objective in totals.keys():
+        for remaining_objective in totals:
             if remaining_objective in seen:
                 continue
             progress_results.append(build_entry(remaining_objective))

--- a/backend/modules/catalog/test_lesson_catalog_unit.py
+++ b/backend/modules/catalog/test_lesson_catalog_unit.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock
 
 from modules.catalog.service import CatalogService, LessonDetail, LessonSummary
+from modules.learning_session.public import ExerciseCorrectness
 from modules.content.package_models import (
     GlossaryTerm,
     LessonPackage,
@@ -194,15 +195,11 @@ class TestCatalogService:
 
         content.get_lessons_by_unit.return_value = [lesson_read]
 
-        learning_sessions.get_sessions_for_lessons.return_value = [
-            SimpleNamespace(
-                session_data={
-                    "exercise_answers": {
-                        "ex-1": {
-                            "has_been_answered_correctly": True,
-                        }
-                    }
-                }
+        learning_sessions.get_exercise_correctness.return_value = [
+            ExerciseCorrectness(
+                lesson_id="lesson-1",
+                exercise_id="ex-1",
+                has_been_answered_correctly=True,
             )
         ]
 

--- a/backend/modules/catalog/test_lesson_catalog_unit.py
+++ b/backend/modules/catalog/test_lesson_catalog_unit.py
@@ -9,7 +9,6 @@ from types import SimpleNamespace
 from unittest.mock import Mock
 
 from modules.catalog.service import CatalogService, LessonDetail, LessonSummary
-from modules.learning_session.public import ExerciseCorrectness
 from modules.content.package_models import (
     GlossaryTerm,
     LessonPackage,
@@ -20,6 +19,7 @@ from modules.content.package_models import (
     Objective,
 )
 from modules.content.public import LessonRead
+from modules.learning_session.public import ExerciseCorrectness
 
 
 class TestCatalogService:

--- a/backend/modules/learning_session/analytics.py
+++ b/backend/modules/learning_session/analytics.py
@@ -4,8 +4,8 @@ Provides read-only aggregation helpers that expose DTOs for other modules
 through the public provider without leaking repository internals.
 """
 
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 from .repo import LearningSessionRepo
 
@@ -25,9 +25,7 @@ class LearningSessionAnalyticsService:
     def __init__(self, repo: LearningSessionRepo) -> None:
         self._repo = repo
 
-    def get_exercise_correctness(
-        self, lesson_ids: Iterable[str]
-    ) -> list[ExerciseCorrectness]:
+    def get_exercise_correctness(self, lesson_ids: Iterable[str]) -> list[ExerciseCorrectness]:
         """Return the aggregated correctness per exercise for the lessons provided."""
 
         aggregated: dict[tuple[str, str], bool] = {}
@@ -36,10 +34,7 @@ class LearningSessionAnalyticsService:
             answers = (session.session_data or {}).get("exercise_answers", {}) or {}
             for exercise_id, answer_data in answers.items():
                 key = (session.lesson_id, exercise_id)
-                is_correct = bool(
-                    answer_data.get("has_been_answered_correctly")
-                    or answer_data.get("is_correct")
-                )
+                is_correct = bool(answer_data.get("has_been_answered_correctly") or answer_data.get("is_correct"))
                 aggregated[key] = aggregated.get(key, False) or is_correct
 
         return [
@@ -50,4 +45,3 @@ class LearningSessionAnalyticsService:
             )
             for (lesson_id, exercise_id), is_correct in aggregated.items()
         ]
-

--- a/backend/modules/learning_session/analytics.py
+++ b/backend/modules/learning_session/analytics.py
@@ -1,0 +1,53 @@
+"""Learning session analytics helpers.
+
+Provides read-only aggregation helpers that expose DTOs for other modules
+through the public provider without leaking repository internals.
+"""
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from .repo import LearningSessionRepo
+
+
+@dataclass(frozen=True)
+class ExerciseCorrectness:
+    """Aggregated correctness flag for a lesson exercise."""
+
+    lesson_id: str
+    exercise_id: str
+    has_been_answered_correctly: bool
+
+
+class LearningSessionAnalyticsService:
+    """Read-only analytics surface for learning session data."""
+
+    def __init__(self, repo: LearningSessionRepo) -> None:
+        self._repo = repo
+
+    def get_exercise_correctness(
+        self, lesson_ids: Iterable[str]
+    ) -> list[ExerciseCorrectness]:
+        """Return the aggregated correctness per exercise for the lessons provided."""
+
+        aggregated: dict[tuple[str, str], bool] = {}
+
+        for session in self._repo.get_sessions_for_lessons(lesson_ids):
+            answers = (session.session_data or {}).get("exercise_answers", {}) or {}
+            for exercise_id, answer_data in answers.items():
+                key = (session.lesson_id, exercise_id)
+                is_correct = bool(
+                    answer_data.get("has_been_answered_correctly")
+                    or answer_data.get("is_correct")
+                )
+                aggregated[key] = aggregated.get(key, False) or is_correct
+
+        return [
+            ExerciseCorrectness(
+                lesson_id=lesson_id,
+                exercise_id=exercise_id,
+                has_been_answered_correctly=is_correct,
+            )
+            for (lesson_id, exercise_id), is_correct in aggregated.items()
+        ]
+

--- a/backend/modules/learning_session/public.py
+++ b/backend/modules/learning_session/public.py
@@ -6,7 +6,8 @@ This is a migration, not new feature development.
 """
 
 from abc import abstractmethod
-from typing import Iterable, Protocol, TYPE_CHECKING
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Protocol
 
 from sqlalchemy.orm import Session
 
@@ -130,7 +131,9 @@ def learning_session_analytics_provider(session: Session) -> LearningSessionAnal
 # Export DTOs that other modules might need
 __all__ = [
     "CompleteSessionRequest",
+    "ExerciseCorrectness",
     "LearningSession",
+    "LearningSessionAnalyticsProvider",
     "LearningSessionProvider",
     "LearningSessionService",
     "SessionListResponse",
@@ -140,8 +143,6 @@ __all__ = [
     "UnitLessonProgress",
     "UnitProgress",
     "UpdateProgressRequest",
-    "learning_session_provider",
-    "LearningSessionAnalyticsProvider",
-    "ExerciseCorrectness",
     "learning_session_analytics_provider",
+    "learning_session_provider",
 ]

--- a/backend/modules/learning_session/repo.py
+++ b/backend/modules/learning_session/repo.py
@@ -5,8 +5,9 @@ Minimal database access layer to support existing frontend functionality.
 This is a migration, not new feature development.
 """
 
+from collections.abc import Iterable
 from datetime import datetime
-from typing import Any, Iterable
+from typing import Any
 import uuid
 
 from sqlalchemy import and_, desc, text
@@ -150,11 +151,7 @@ class LearningSessionRepo:
         if not lesson_ids:
             return []
 
-        return (
-            self.db.query(LearningSessionModel)
-            .filter(LearningSessionModel.lesson_id.in_(lesson_ids))
-            .all()
-        )
+        return self.db.query(LearningSessionModel).filter(LearningSessionModel.lesson_id.in_(lesson_ids)).all()
 
     def assign_session_user(self, session_id: str, user_id: str) -> LearningSessionModel:
         """Persist the user association for a session if it has not been set."""

--- a/backend/modules/learning_session/repo.py
+++ b/backend/modules/learning_session/repo.py
@@ -6,7 +6,7 @@ This is a migration, not new feature development.
 """
 
 from datetime import datetime
-from typing import Any
+from typing import Any, Iterable
 import uuid
 
 from sqlalchemy import and_, desc, text
@@ -141,6 +141,19 @@ class LearningSessionRepo:
                 )
             )
             .first()
+        )
+
+    def get_sessions_for_lessons(self, lesson_ids: Iterable[str]) -> list[LearningSessionModel]:
+        """Return all sessions associated with the provided lesson identifiers."""
+
+        lesson_ids = list(lesson_ids)
+        if not lesson_ids:
+            return []
+
+        return (
+            self.db.query(LearningSessionModel)
+            .filter(LearningSessionModel.lesson_id.in_(lesson_ids))
+            .all()
         )
 
     def assign_session_user(self, session_id: str, user_id: str) -> LearningSessionModel:

--- a/backend/modules/learning_session/routes.py
+++ b/backend/modules/learning_session/routes.py
@@ -75,6 +75,8 @@ class ProgressResponseModel(BaseModel):
     user_answer: dict[str, Any] | None
     time_spent_seconds: int
     attempts: int
+    attempt_history: list[dict[str, Any]]
+    has_been_answered_correctly: bool
 
 
 class SessionResultsResponseModel(BaseModel):
@@ -221,6 +223,8 @@ async def update_session_progress(
         user_answer=progress.user_answer,
         time_spent_seconds=progress.time_spent_seconds,
         attempts=progress.attempts,
+        attempt_history=progress.attempt_history,
+        has_been_answered_correctly=progress.has_been_answered_correctly,
     )
 
 

--- a/backend/modules/learning_session/service.py
+++ b/backend/modules/learning_session/service.py
@@ -8,11 +8,11 @@ This is a migration, not new feature development.
 from dataclasses import dataclass
 from datetime import datetime
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from modules.catalog.public import CatalogProvider
-
-from ..content.public import ContentProvider
+if TYPE_CHECKING:
+    from modules.catalog.public import CatalogProvider
+    from modules.content.public import ContentProvider
 from .models import LearningSessionModel, SessionStatus
 from .repo import LearningSessionRepo
 
@@ -164,8 +164,8 @@ class LearningSessionService:
     def __init__(
         self,
         repo: LearningSessionRepo,
-        content_provider: ContentProvider,
-        catalog_provider: CatalogProvider,
+        content_provider: "ContentProvider",
+        catalog_provider: "CatalogProvider",
     ) -> None:
         self.repo = repo
         self.content = content_provider

--- a/mobile/e2e/learning-flow.yaml
+++ b/mobile/e2e/learning-flow.yaml
@@ -41,6 +41,8 @@ appId: host.exp.Exponent
 # Step 4: Answer MCQ questions
 # Question 1
 - assertVisible:
+    text: "Volunteers share feeding and water duties"
+- assertVisible:
     id: 'mcq-choice-0'
 - tapOn:
     id: 'mcq-choice-0'
@@ -48,6 +50,8 @@ appId: host.exp.Exponent
     id: 'mcq-continue-button'
 
 # Question 2
+- assertVisible:
+    text: "They guard the fish market at night"
 - assertVisible:
     id: 'mcq-choice-1'
 - tapOn:

--- a/mobile/modules/catalog/test_catalog_unit.ts
+++ b/mobile/modules/catalog/test_catalog_unit.ts
@@ -123,6 +123,14 @@ describe('CatalogService', () => {
         isGlobal: false,
         ownershipLabel: 'My Unit',
         isOwnedByCurrentUser: true,
+        learningObjectiveProgress: [
+          {
+            objective: 'Understand A',
+            exercisesTotal: 2,
+            exercisesCorrect: 1,
+            progressPercentage: 50,
+          },
+        ],
       };
       mockContent.getUnitDetail.mockResolvedValue(detail);
 

--- a/mobile/modules/content/models.ts
+++ b/mobile/modules/content/models.ts
@@ -42,6 +42,12 @@ export interface ApiUnitDetail {
   generated_from_topic?: boolean;
   user_id?: number | null;
   is_global?: boolean;
+  learning_objective_progress?: Array<{
+    objective: string;
+    exercises_total: number;
+    exercises_correct: number;
+    progress_percentage: number;
+  }> | null;
 }
 
 export type UnitId = string;
@@ -103,6 +109,14 @@ export interface UnitDetail {
   readonly isGlobal: boolean;
   readonly ownershipLabel: string;
   readonly isOwnedByCurrentUser: boolean;
+  readonly learningObjectiveProgress?: LearningObjectiveProgress[] | null;
+}
+
+export interface LearningObjectiveProgress {
+  readonly objective: string;
+  readonly exercisesTotal: number;
+  readonly exercisesCorrect: number;
+  readonly progressPercentage: number;
 }
 
 export interface UnitProgress {
@@ -200,6 +214,14 @@ export function toUnitDetailDTO(
     isGlobal,
     ownershipLabel: formatOwnershipLabel(isGlobal, isOwnedByCurrentUser),
     isOwnedByCurrentUser,
+    learningObjectiveProgress: api.learning_objective_progress
+      ? api.learning_objective_progress.map(progress => ({
+          objective: progress.objective,
+          exercisesTotal: progress.exercises_total,
+          exercisesCorrect: progress.exercises_correct,
+          progressPercentage: progress.progress_percentage,
+        }))
+      : null,
   };
 }
 

--- a/mobile/modules/learning_session/models.ts
+++ b/mobile/modules/learning_session/models.ts
@@ -32,6 +32,14 @@ interface ApiSessionProgress {
   user_answer?: any;
   time_spent_seconds: number;
   attempts: number;
+  attempt_history?: Array<{
+    attempt_number: number;
+    is_correct?: boolean;
+    user_answer?: any;
+    time_spent_seconds: number;
+    submitted_at: string;
+  }>;
+  has_been_answered_correctly?: boolean;
 }
 
 interface ApiSessionResults {
@@ -79,6 +87,14 @@ export interface SessionProgress {
   readonly attempts: number;
   readonly isCompleted: boolean; // Calculated
   readonly accuracy: number; // Calculated (0-1)
+  readonly attemptHistory?: Array<{
+    attemptNumber: number;
+    isCorrect?: boolean;
+    userAnswer?: any;
+    timeSpentSeconds: number;
+    submittedAt: string;
+  }>;
+  readonly hasBeenAnsweredCorrectly?: boolean;
 }
 
 export interface SessionResults {
@@ -286,6 +302,16 @@ export function toSessionProgressDTO(api: ApiSessionProgress): SessionProgress {
     attempts: api.attempts,
     isCompleted,
     accuracy,
+    attemptHistory: api.attempt_history
+      ? api.attempt_history.map(attempt => ({
+          attemptNumber: attempt.attempt_number,
+          isCorrect: attempt.is_correct,
+          userAnswer: attempt.user_answer,
+          timeSpentSeconds: attempt.time_spent_seconds,
+          submittedAt: attempt.submitted_at,
+        }))
+      : undefined,
+    hasBeenAnsweredCorrectly: api.has_been_answered_correctly,
   };
 }
 

--- a/mobile/modules/learning_session/test_learning_session_unit.ts
+++ b/mobile/modules/learning_session/test_learning_session_unit.ts
@@ -200,6 +200,16 @@ describe('Learning Session Module', () => {
           user_answer: 'A',
           time_spent_seconds: 30,
           attempts: 1,
+          attempt_history: [
+            {
+              attempt_number: 1,
+              is_correct: true,
+              user_answer: 'A',
+              time_spent_seconds: 30,
+              submitted_at: '2024-01-01T00:00:30Z',
+            },
+          ],
+          has_been_answered_correctly: true,
         };
 
         const mockSession = {
@@ -229,7 +239,9 @@ describe('Learning Session Module', () => {
           userAnswer: 'A',
           timeSpentSeconds: 30,
           attempts: 1,
+          hasBeenAnsweredCorrectly: true,
         });
+        expect(result.attemptHistory).toHaveLength(1);
 
         expect(mockRepo.updateProgress).toHaveBeenCalledWith({
           ...request,


### PR DESCRIPTION
## Summary
- record every learning exercise attempt with a detailed history and persistent correctness flags
- aggregate learning-objective progress per unit by combining lesson metadata with recorded session data
- expose the new progress data in the admin unit detail view and update shared/mobile DTO mappings

## Testing
- pytest backend/modules/learning_session/test_learning_session_unit.py backend/modules/catalog/test_lesson_catalog_unit.py

------
https://chatgpt.com/codex/tasks/task_e_68d8d5f9c434832cabd11dd6fd8b506f