### PR TITLE
Use object store for AI-generated cover images

### DIFF
--- a/backend/alembic/versions/1f64f2a8bde0_add_unit_cover_image_object_id.py
+++ b/backend/alembic/versions/1f64f2a8bde0_add_unit_cover_image_object_id.py
@@ -1,0 +1,23 @@
+"""add cover_image_object_id to units"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision = "1f64f2a8bde0"
+down_revision = "d3c8f2b7b3fb"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "units",
+        sa.Column("cover_image_object_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("units", "cover_image_object_id")

--- a/backend/modules/content/models.py
+++ b/backend/modules/content/models.py
@@ -80,6 +80,7 @@ class UnitModel(Base):
     cover_image_url = Column(Text, nullable=True)
     cover_image_prompt = Column(Text, nullable=True)
     cover_image_request_id = Column(PostgresUUID(as_uuid=True), nullable=True)
+    cover_image_object_id = Column(PostgresUUID(as_uuid=True), nullable=True)
 
     created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
     updated_at = Column(DateTime, nullable=False, default=datetime.utcnow)


### PR DESCRIPTION
## Summary
- add an alembic migration to capture the object store image id for unit covers
- upload generated cover art into the object store and persist the returned metadata when creating units
- extend unit tests to validate the object store happy path and the fallback behaviour

## Testing
- pytest backend/modules/content/test_content_unit.py

------
https://chatgpt.com/codex/tasks/task_e_68d9f40e501c832c85d60e41e4dfc9bd